### PR TITLE
fix: remove redundant entries check in ad constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Construct A Provider with the peerID and signing keys, and pass it to an Adverti
 Call `advertisement.signAndEncode()` to export a valid Advertisement ready for encoding as IPLD.
 
 ```js
-import fs from 'node:fs/promises'
+import fs from 'node:fs'
 import { CID } from 'multiformats/cid'
 import * as Block from 'multiformats/block'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -93,7 +93,6 @@ An `dag-json` encoded Advertisement (re-formated for readability):
   }
 }
 ```
-
 
 ## Extended Providers
 

--- a/advertisement.js
+++ b/advertisement.js
@@ -64,7 +64,7 @@ export class Advertisement {
    * @param {boolean} [config.override]
    */
   constructor ({ previous, providers, context, entries = NO_ENTRIES, remove = false, override = false }) {
-    if (!providers || !entries || !context) {
+    if (!providers || !context) {
       throw new Error('providers and context are required')
     }
     if (previous === undefined) {
@@ -126,7 +126,6 @@ export class Advertisement {
    * Serialize the fields use for signing the Advertisement
    * note: peerId and multiaddr string bytes are signed rather than using their byte encodings!
    * impl: https://github.com/ipni/go-libipni/blob/afe2d8ea45b86c2a22f756ee521741c8f99675e5/ingest/schema/envelope.go#L84
-   * spec: https://github.com/ipni/specs/blob/main/IPNI.md#extendedprovider
    */
   signableBytes () {
     const text = new TextEncoder()


### PR DESCRIPTION
entries now has a default value so the check is not needed.

and fix some typos

License: MIT