### PR TITLE
feat: createExtendedProviderAd helper to guide extended provider usage

### DIFF
--- a/advertisement.js
+++ b/advertisement.js
@@ -67,7 +67,7 @@ export class Advertisement {
    * @param {Link | null} config.entries - CID for an EntryBatch, an array of content multihashes you're providing
    * @param {Bytes | null} config.context - A custom id used to group subsets of advertisements
    * @param {boolean} [config.remove] - true if this represents entries that are no longer retrievable.
-   * @param {boolean} [config.override] -
+   * @param {boolean} [config.override] - true if the extended providers specified should be used instead of any previously announced without a context.
    */
   constructor ({ previous, providers, context, entries, remove = false, override = false }) {
     if (!providers) {
@@ -93,7 +93,7 @@ export class Advertisement {
     this.override = override
     if (this.remove && this.providers.length > 1) {
       // see: https://github.com/ipni/go-libipni/blob/afe2d8ea45b86c2a22f756ee521741c8f99675e5/ingest/schema/envelope.go#L126-L127
-      throw new Error('remove may only be true when there is a single provider. IsRm is not support for ExtendedProvider advertisement')
+      throw new Error('remove may only be true when there is a single provider. IsRm is not supported for ExtendedProvider advertisements')
     }
     if (this.override && (this.context.byteLength === 0 || this.providers.length < 2)) {
       throw new Error('override may only be true when a context is set and more than 1 provider')
@@ -172,13 +172,14 @@ export class Advertisement {
  * see: https://github.com/ipni/storetheindex/issues/1745
  *
  * @param {object} config
- * @param {Provider[]} config.providers
- * @param {Link | null} config.previous
- * @param {Bytes | null} [config.context]
+ * @param {Link | null} config.previous - CID of previous Advertisement
+ * @param {Provider[]} config.providers - Two or more Provider objects where entries are available
+ * @param {Bytes | null} [config.context] - A custom id used to group subsets of advertisements
+ * @param {boolean} [config.override] - true if the providers should be used instead of any previously announced without a context.
  */
-export function createExtendedProviderAd ({ previous, providers, context = null }) {
+export function createExtendedProviderAd ({ previous, providers, context = null, override = false }) {
   if (!providers || !Array.isArray(providers) || providers.length < 2) {
     throw new Error('at least 2 providers are required, the root provider and the new extended provider')
   }
-  return new Advertisement({ previous, providers, entries: null, context })
+  return new Advertisement({ previous, providers, entries: null, context, override })
 }

--- a/advertisement.js
+++ b/advertisement.js
@@ -85,9 +85,6 @@ export class Advertisement {
     if (context !== null && context.byteLength > MAX_CONTEXT_ID_LENGTH) {
       throw new Error(`context must be less than ${MAX_CONTEXT_ID_LENGTH} bytes`)
     }
-    if (override && !context) {
-      throw new Error('override may only be true when a context is set')
-    }
     this.providers = Array.isArray(providers) ? providers : [providers]
     this.previous = previous
     this.entries = entries ?? NO_ENTRIES
@@ -96,7 +93,10 @@ export class Advertisement {
     this.override = override
     if (this.remove && this.providers.length > 1) {
       // see: https://github.com/ipni/go-libipni/blob/afe2d8ea45b86c2a22f756ee521741c8f99675e5/ingest/schema/envelope.go#L126-L127
-      throw new Error('rm ads are not supported for extended provider signatures')
+      throw new Error('remove may only be true when there is a single provider. IsRm is not support for ExtendedProvider advertisement')
+    }
+    if (this.override && (this.context.byteLength === 0 || this.providers.length < 2)) {
+      throw new Error('override may only be true when a context is set and more than 1 provider')
     }
   }
 

--- a/examples/extended-providers.js
+++ b/examples/extended-providers.js
@@ -5,11 +5,9 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import * as dagJson from '@ipld/dag-json'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 
-import { Provider, Advertisement } from '../index.js'
+import { Provider, createExtendedProviderAd } from '../index.js'
 
-const previous = null // CID for previous batch. Pass `null` for the first advertisement in your chain
-const entries = CID.parse('baguqeera4vd5tybgxaub4elwag6v7yhswhflfyopogr7r32b7dpt5mqfmmoq') // entry batch to provide
-const context = new Uint8Array([99]) // custom id for a set of multihashes
+const previous = null // CID for previous advertisement. Pass `null` for the first advertisement in your chain
 
 // create a provider for each peer + protocol that will provider your entries
 const bits = new Provider({ protocol: 'bitswap', addresses: ['/ip4/12.34.56.1/tcp/999/ws'], peerId: await createEd25519PeerId() })
@@ -25,8 +23,9 @@ const graf = new Provider({
   }
 })
 
-// an advertisement with a single multiple providers
-const advert = new Advertisement({ providers: [http, bits, graf], entries, context, previous })
+// create an ad with the extra provider info and no context or entries
+// to denote that they apply to all previous and future advertisements
+const advert = createExtendedProviderAd({ providers: [http, bits, graf], previous })
 
 // sign and export to IPLD form per schema
 const value = await advert.encodeAndSign()

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 export { Provider } from './provider.js'
-export { Advertisement } from './advertisement.js'
+export { Advertisement, createExtendedProviderAd } from './advertisement.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ipni",
+  "name": "@web3-storage/ipni",
   "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ipni",
+      "name": "@web3-storage/ipni",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -246,7 +246,7 @@ test('remove', async t => {
   const remove = true
   t.throws(
     () => new Advertisement({ remove, previous, context, providers: [provider, provider], entries }),
-    { message: 'remove may only be true when there is a single provider. IsRm is not support for ExtendedProvider advertisement' }
+    { message: 'remove may only be true when there is a single provider. IsRm is not supported for ExtendedProvider advertisements' }
   )
 
   const ad = new Advertisement({ remove, previous, context, providers: provider, entries })


### PR DESCRIPTION
the expected way to use extended providers is with a special advert that doesn't include a context or entries, so a helper is provider to help guide usage. The Advertisement constructor lets you do anything that's legal but requires you to pass null for the special case of a ad with no context id, entries or previous cid. While the helper lets you skip those nulls as you've clearly opt'd in to the extendedProvider world.

```js
/**
 * Advertise that **all** past and future entries in this chain are now
 * available from a new, additional provider by specifying the root provider
 * and the additional providers along with no context id and no entries cid.
 *
 * To advertise that subset of entries are available from additional providers
 * specify the relevant context id to identify that group.
 *
 * Note: it is not yet possible to unannounce an extended provider once announced.
 * see: https://github.com/ipni/storetheindex/issues/1745
 *
 * @param {object} config
 * @param {Provider[]} config.providers
 * @param {Link | null} config.previous
 * @param {Bytes | null} [config.context]
 */
export function createExtendedProviderAd ({ previous, providers, context = null }) {
  if (!providers || !Array.isArray(providers) || providers.length < 2) {
    throw new Error('at least 2 providers are required, the root provider and the new extended provider')
  }
  return new Advertisement({ previous, providers, entries: null, context })
}
```

Adds and reworks some missing validation checks and typos.

License: MIT