### PR TITLE
fix: add test for previous encoding interop with go

### DIFF
--- a/advertisement.js
+++ b/advertisement.js
@@ -112,18 +112,18 @@ export class Advertisement {
       Provider: provider.peerId.toString(),
       Addresses: provider.addresses.map(a => a.toString()),
       Signature: await sign(provider.peerId, ad.signableBytes(), AD_SIG_CODEC),
-      Entries: this.entries,
-      ContextID: this.context,
+      Entries: ad.entries,
+      ContextID: ad.context,
       Metadata: provider.encodeMetadata(),
-      IsRm: this.remove
+      IsRm: ad.remove
     }
-    if (this.previous) {
-      value.PreviousID = this.previous
+    if (ad.previous) {
+      value.PreviousID = ad.previous
     }
     // ExtendedProvider mode!
-    if (this.providers.length > 1) {
+    if (ad.providers.length > 1) {
       const Providers = []
-      for (const p of this.providers) {
+      for (const p of ad.providers) {
         Providers.push({
           ID: p.peerId.toString(),
           Addresses: p.addresses.map(a => a.toString()),
@@ -133,7 +133,7 @@ export class Advertisement {
       }
       value.ExtendedProvider = {
         Providers,
-        Override: this.override
+        Override: ad.override
       }
     }
     return value

--- a/scripts/gen-ipni-fixture/main.go
+++ b/scripts/gen-ipni-fixture/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipni/index-provider/engine/xproviders"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -34,9 +35,15 @@ func main() {
 		panic(err)
 	}
 
+	previous, err := cid.Parse("baguqeera7izo6lfcvowkpqg2jjuo2hgglxy5bfbtwla7i4if6zxuhhe3yu4q")
+	if err != nil {
+		panic(err)
+	}
+
 	addrs := []multiaddr.Multiaddr{mustParseMultiaddr(provider.Addrs[0])}
 
 	advert, err := xproviders.NewAdBuilder(mustDecodePeerID(provider.ID), provider.Priv, addrs).
+		WithLastAdID(previous).
 		WithContextID(contextID).
 		WithMetadata(provider.Metadata).
 		WithOverride(false).

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -131,6 +131,25 @@ test('extended provider interop', async t => {
   t.deepEqual(decode(encode(value)), decode(encode(expected)))
 })
 
+test('extended provider interop with previous', async t => {
+  const expected = JSON.parse(await readFile('test/fixtures/ad-4/ad.json', { encoding: 'utf-8' }))
+  const previous = CID.parse(expected.PreviousID['/'])
+  const p1 = new Provider({
+    protocol: 'bitswap',
+    addresses: expected.ExtendedProvider?.Providers[0].Addresses,
+    peerId: await loadPeerId('test/fixtures/ad-1/peerId.json')
+  })
+  const p2 = new Provider({
+    protocol: 'bitswap',
+    addresses: expected.ExtendedProvider?.Providers[1].Addresses,
+    peerId: await loadPeerId('test/fixtures/ad-2/peerId.json')
+  })
+  const context = Buffer.from(expected.ContextID['/'].bytes, 'base64')
+  const ad = new Advertisement({ providers: [p1, p2], context, entries: null, previous })
+  const value = await ad.encodeAndSign()
+  t.deepEqual(decode(encode(value)), decode(encode(expected)))
+})
+
 test('parity with publisher-lambda no previous', async t => {
   const expected = JSON.parse(await readFile('test/fixtures/ad-1/ad.json', { encoding: 'utf-8' }))
   const entries = CID.parse(expected.Entries['/'])

--- a/test/fixtures/ad-4/ad.json
+++ b/test/fixtures/ad-4/ad.json
@@ -1,0 +1,65 @@
+{
+  "Addresses": [
+    "/ip4/12.34.56.78/tcp/999/ws"
+  ],
+  "ContextID": {
+    "/": {
+      "bytes": "YmFndXFlZXJhNHZkNXR5Ymd4YXViNGVsd2FnNnY3eWhzd2hmbGZ5b3BvZ3I3cjMyYjdkcHQ1bXFmbW1vcQ"
+    }
+  },
+  "Entries": {
+    "/": "bafkreehdwdcefgh4dqkjv67uzcmw7oje"
+  },
+  "ExtendedProvider": {
+    "Override": false,
+    "Providers": [
+      {
+        "Addresses": [
+          "/ip4/12.34.56.78/tcp/999/ws"
+        ],
+        "ID": "QmVRvNE5oikD3aPkNfCLufvwQPsjvwYiwxS4PyAktTU2fM",
+        "Metadata": {
+          "/": {
+            "bytes": "gBI"
+          }
+        },
+        "Signature": {
+          "/": {
+            "bytes": "CqsCCAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAVBkdP8VR72bWmtugfzEcWOkC8FCvS9WlgT05bedleDxLYhUZuNmlyd2e4SPrXx6SRJeoRZ/Cs8YZ/tz5Api/4inytCZl1fG3VVpeKXRv4bpkxcl0ZXWMLwT2vxxXtTXq/3yaUMVIelqxRWLK58PzBsbeDydWMcMfxta2z7Mp1sUQmcQ1nNk5HjWetVXrPW6/RtfvcLLU6FHw3nROOFye8qbg+KH697DJZOLgroJwzmCxvstaIsLs1G7z2hZt7/oWoiMbC/lGMwzYBRKxiEK7LA/28qnY1VIxMO9x1MWke5Su1NBlHl5EfiFPGXmKyIzkW80CCxHKek9M+YEM0G5LAgMBAAESKS9pbmRleGVyL2luZ2VzdC9leHRlbmRlZFByb3ZpZGVyU2lnbmF0dXJlGiISIEsueqs8l+yO6nU/vF2An+Y9ktaYQTQdi/4MooUUGXhTKoACQv5+g1iFGw+Ad8070zju4OJ1gAzXN0Sp7p3uu9zHV9xykf3yhzCK7M8w07eh77FWEEQzlUMX0ScmRLK5MXa/OWvcw0VmSTlqLIxg673z5RXw28S0FsMtQSuWIHjGDcS9xRa2f0/vbw3GtU9cwa17aZGQ1Q+I09S2SkEzX1g5vsVY8RbH7hgR7EdudRvQ+7SlXhZdDsw7bsuWj0X9KjBEYTjXCjI4JjR2QaMn7VbVvSxyIN3fL6gfuMsfhmXZuKDJBmWuTRNVaFQBt2GIfkbdi54DHMebN0jlr2zWxMJLrRLSEYPjlS6fpViw473R2fVaH45HT/ml/g3Zk1NsmhBN2A"
+          }
+        }
+      },
+      {
+        "Addresses": [
+          "/ip4/12.34.56.78/tcp/999/ws"
+        ],
+        "ID": "QmTkkmVimdmeZVxULqfJj99UB2uHSp33eMQ5LoEF8FMPLC",
+        "Metadata": {
+          "/": {
+            "bytes": "gBI"
+          }
+        },
+        "Signature": {
+          "/": {
+            "bytes": "CqsCCAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCTK1c21lGcPN16/9KJyzmATCgKOAotEpssVLVyd968m5bnkMAq++daG63ku+CN7lkb9P29+b+dw7GIe8ImW1/NwFY8S2D/SKySWEXdESuavJIvHmUZKwfxRam4Rn4ddfvAX9KDmgp8oRxnY9Pp6fX4lWTKWGXTaxLvjQXQW8KgPJr68hV559or6s6viaKORExkWgbJIzFn07IqrKLoCz8O2PiR36elGK11DFA5lHT226u57NMM61x7WwQ1dfbBaW3Gjc6Ow1oQHfhgnYEPa/oTnQUkS8B95fjiEme6zaveMNATqsc+uG0+tqZtwmsgBQjMFhDKnWAY0fmJ1K7nPDsNAgMBAAESKS9pbmRleGVyL2luZ2VzdC9leHRlbmRlZFByb3ZpZGVyU2lnbmF0dXJlGiISIH3TLquZkSV+6hU353O2/6A3RJq82V3kzGRqIpdN6DFmKoACb1ff6kcW7vVOtyZfh3dCQq/wN7OD2NXRsLfgMQ8+XN3IesGPbQMhU1nLmtIP7q3LDFHfxMi/4ZWhQfYoHNRkzihy/RKb5WC67MsxVqD4HUqx2GiLS02mqrDMBwzMTP7vTy+PNw8kaZsAR9q9YLWn+9koye1eFUtR+CQ8xiowkK88z4h/b1s+YNDzWMTssxEWifrDiPWyJqnlDXy1EyTiPWYLREsVLnYr7Eb3xDlFT4rBssLbV8OKKw9lSlnreNmLc5VtX/M3f55EtZmtVChfyqe1o36hVjjZ6wYcOxod6ZAgpIapxm6IDy9u2V6zWFJiYkJzNJamLvv5vpqIK1kJtg"
+          }
+        }
+      }
+    ]
+  },
+  "IsRm": false,
+  "Metadata": {
+    "/": {
+      "bytes": "gBI"
+    }
+  },
+  "PreviousID": {
+    "/": "baguqeera7izo6lfcvowkpqg2jjuo2hgglxy5bfbtwla7i4if6zxuhhe3yu4q"
+  },
+  "Provider": "QmVRvNE5oikD3aPkNfCLufvwQPsjvwYiwxS4PyAktTU2fM",
+  "Signature": {
+    "/": {
+      "bytes": "CqsCCAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAVBkdP8VR72bWmtugfzEcWOkC8FCvS9WlgT05bedleDxLYhUZuNmlyd2e4SPrXx6SRJeoRZ/Cs8YZ/tz5Api/4inytCZl1fG3VVpeKXRv4bpkxcl0ZXWMLwT2vxxXtTXq/3yaUMVIelqxRWLK58PzBsbeDydWMcMfxta2z7Mp1sUQmcQ1nNk5HjWetVXrPW6/RtfvcLLU6FHw3nROOFye8qbg+KH697DJZOLgroJwzmCxvstaIsLs1G7z2hZt7/oWoiMbC/lGMwzYBRKxiEK7LA/28qnY1VIxMO9x1MWke5Su1NBlHl5EfiFPGXmKyIzkW80CCxHKek9M+YEM0G5LAgMBAAESGy9pbmRleGVyL2luZ2VzdC9hZFNpZ25hdHVyZRoiEiCR0ZbieRVzR1I8fbar+TqEMZIvRdHwHJ1w/IjshnDxgCqAArsggeG/dY+Y31BlxO2TFUnmCzdR96txzhVsOHPkN0lzNL9GejLtzPMOwPVeyDDOXX0AuQIjMuq1TpZwxNENq8vquU5FcsETpvKkGhDMHK/LfwP0nJoEVCpeW8FU2XSbF8Xmw06IuS0/Gi01NCyat7QcGavm4lIBqHRN1Oa7j4tErs2PWvkleYOqJHy2sZ3CEg0PTtIn73tiENmg+4cmi8cKuE5V/LC/u2fV6gBRX6VTq0p6YnP1ogfEbKWob05LC8ev7kBqIa8gckbP8/1SFbi2mBeSpAKHHP9WdMotOxiNE+lwPaAtLLmyWZHfH+zZ4bD/tdVdZx+eQspvoJxMV5o"
+    }
+  }
+}


### PR DESCRIPTION
- test that an extended provider ad with previous matches one that go would produce
- refactor encodeAndSign to always use `ad` over `this` for consistency

License: MIT