### PR TITLE
Update to correct protocol prefix for HTTP

### DIFF
--- a/provider.js
+++ b/provider.js
@@ -17,7 +17,7 @@ import varint from 'varint'
 // see: https://github.com/ipni/specs/blob/main/IPNI.md#metadata
 export const GRAPHSYNC_PREFIX = new Uint8Array(varint.encode(0x0910))
 export const BITSWAP_PREFIX = new Uint8Array(varint.encode(0x900))
-export const HTTP_PREFIX = new Uint8Array(varint.encode(0x3D0000))
+export const HTTP_PREFIX = new Uint8Array(varint.encode(0x0920))
 
 /**
  * Define where and how your entries can be fetched.


### PR DESCRIPTION
# Goals

Looks like you guys were using the custom address range for HTTP transport, not the one that's needed for Lassie, which is HTTP Trustless Gateway, aka 0x920 (https://github.com/multiformats/multicodec/blob/master/table.csv#L147)

So your HTTP advertisement is getting published, but Lassie isn't picking it up.