### PR TITLE
fix!: add a varint 0 for http to match go-libipni

### DIFF
--- a/provider.js
+++ b/provider.js
@@ -64,7 +64,7 @@ export class Provider {
   * @param {GraphsyncMetadata} [metadata] - required if protocol is `graphsync`
   */
   encodeMetadata (protocol = this.protocol, metadata = this.metadata) {
-    if (protocol === 'http') return HTTP_PREFIX
+    if (protocol === 'http') return concat([HTTP_PREFIX, new Uint8Array(varint.encode(0))])
     if (protocol === 'bitswap') return BITSWAP_PREFIX
     if (protocol === 'graphsync') {
       if (!metadata) throw new Error('metadata is required')

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -7,6 +7,8 @@ import { readFile } from 'fs/promises'
 import { Provider, HTTP_PREFIX, BITSWAP_PREFIX, GRAPHSYNC_PREFIX } from '../provider.js'
 import { Advertisement, hashSignableBytes, createExtendedProviderAd } from '../advertisement.js'
 import { encode, decode } from '@ipld/dag-json'
+import varint from 'varint'
+import { concat } from 'uint8arrays/concat'
 
 const schema = await readFile('schema.ipldsch', { encoding: 'utf8' })
 const adValidator = createValidator(parseSchema(schema), 'Advertisement')
@@ -25,7 +27,7 @@ test('one provider', async t => {
     Addresses: addresses,
     Entries: entries,
     ContextID: context,
-    Metadata: HTTP_PREFIX,
+    Metadata: concat([HTTP_PREFIX, new Uint8Array(varint.encode(0))]),
     IsRm: false
   })
   t.falsy(encoded.PreviousID, 'previous is not set')
@@ -103,7 +105,7 @@ test('extended providers', async t => {
   t.like(encoded.ExtendedProvider?.Providers[1], {
     ID: http.peerId.toString(),
     Addresses: [http.addresses[0].toString()],
-    Metadata: HTTP_PREFIX
+    Metadata: concat([HTTP_PREFIX, new Uint8Array(varint.encode(0))])
   })
   t.like(encoded.ExtendedProvider?.Providers[2], {
     ID: graph.peerId.toString(),

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -3,6 +3,8 @@ import { CID } from 'multiformats/cid'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { Provider, HTTP_PREFIX, BITSWAP_PREFIX, GRAPHSYNC_PREFIX } from '../provider.js'
 import { Advertisement } from '../advertisement.js'
+import varint from 'varint'
+import { concat } from 'uint8arrays/concat'
 
 test('http', async t => {
   const peerId = await createEd25519PeerId()
@@ -10,7 +12,7 @@ test('http', async t => {
   const hp = new Provider({ protocol: 'http', peerId, addresses })
 
   const meta = hp.encodeMetadata()
-  t.deepEqual(meta, HTTP_PREFIX)
+  t.deepEqual(meta, concat([HTTP_PREFIX, new Uint8Array(varint.encode(0))]))
 
   const entries = CID.parse('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
   const context = new Uint8Array([99])


### PR DESCRIPTION
Getting an error still decoding HTTP advertisements in go. Looks like it's due to the fact that HTTP encodes a varint(0) for the payload size -- see https://github.com/ipni/go-libipni/pull/22#discussion_r1175354812

Tagging @willscott and @masih for visibility. I wonder if there is a way we can generate a valid ad and verify against it.